### PR TITLE
camelCase keys for multi-word models.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-generate-ember-blueprints",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generate a Ember Data compatible blueprints in your Sails project.",
   "author": {
     "name": "Marcus Paeschke",

--- a/templates/api/blueprints/_util/actionUtil.js
+++ b/templates/api/blueprints/_util/actionUtil.js
@@ -31,7 +31,13 @@ module.exports = {
 
     var plural = Array.isArray( records ) ? true : false;
 
-    var documentIdentifier = plural ? pluralize( model.identity ) : model.identity;
+    var documentIdentifier = plural ? pluralize( model.globalId ) : model.globalId;
+    //turn id into camelCase for ember
+    documentIdentifier = documentIdentifier.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g,
+    function(match, index) {
+      if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces
+      return index == 0 ? match.toLowerCase() : match.toUpperCase();
+    });
     var json = {};
 
     json[ documentIdentifier ] = plural ? [] : {};


### PR DESCRIPTION
See https://github.com/artificialio/sane/issues/61

Has been tested on my local project with a couple of different models.

so for example a model `CompanyDocuments` will now have a root-key of `companyDocuments` rather than `companydocuments`.
