### PR TITLE
Create the directory we are installing to if it does not exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,11 @@ module.exports = {
         // copy blueprint and service files
         console.log( 'Installing "' + scope.flavor + '" of blueprints.' );
 
+        // create blueprints directory if it does not exist
+        if( ! fs.existsSync( scope.rootPath + '/api/blueprints' ) ) {
+          fs.mkdirSync( scope.rootPath + '/api/blueprints' );
+        }
+
         ['create', 'destroy', 'find', 'findone', 'populate', 'update'].forEach(function(blueprint) {
           fs.writeFileSync(scope.rootPath + '/api/blueprints/' + blueprint + '.js', "module.exports = require('sails-generate-ember-blueprints/templates/" + scope.flavor + "/api/blueprints/" + blueprint + ".js');\n");
         });


### PR DESCRIPTION
Was having an issue with sane-cli during:

``` BASH
sails generate ember-blueprints
```

I tracked it down to the /api/blueprints folder not existing when we go to install files to it. So I added this call to create the directory if it does not exist.

EDIT: Here is the error:

``` BASH
Running generator (sails-generate-ember-blueprints) @ `/home/bcasey/qaap/server`...
Installing "basic" of blueprints.
fs.js:568
  function strWrapper(err, written) {
                ^
Error: ENOENT, no such file or directory '/home/bcasey/qaap/server/api/blueprints/create.js'
    at Error (native)
    at Object.fs.openSync (fs.js:502:18)
    at Object.fs.writeFileSync (fs.js:1103:15)
    at /home/bcasey/qaap/server/node_modules/sails-generate-ember-blueprints/lib/index.js:36:14
    at Array.forEach (native)
    at Object.module.exports.targets../.exec (/home/bcasey/qaap/server/node_modules/sails-generate-ember-blueprints/lib/index.js:35:72)
    at afterwards (/usr/local/lib/node_modules/sails/node_modules/sails-generate/lib/target.js:61:23)
    at Object.async.until (/usr/local/lib/node_modules/sails/node_modules/sails-generate/node_modules/async/lib/async.js:655:13)
    at generateTarget (/usr/local/lib/node_modules/sails/node_modules/sails-generate/lib/target.js:39:9)
    at /usr/local/lib/node_modules/sails/node_modules/sails-generate/lib/generate.js:155:11
```
