### PR TITLE
Handle indexing of *hasMany-through* associations.

### DIFF
--- a/templates/advanced/api/blueprints/_util/actionUtil.js
+++ b/templates/advanced/api/blueprints/_util/actionUtil.js
@@ -39,42 +39,6 @@ module.exports = {
 	},
 
 	/**
-	 * AccessControl proxy function, expects a Waterline query object for before* hooks and an array of records for after* hooks.
-	 * @param  {Collection} model             Waterline collectio, from parseModel
-	 * @param  {String} action                blueprint or hook, e.g. beforeFind, afterFind, beforeCreate, afterCreate --> translates to accessControlBeforeFind, etc.
-	 * @param  {Object} options               Options: query {Query} Waterline query object for before* hooks, records: {Array} records for after* hooks, {Model} current user record
-	 * @return {Query|Array}                  returns the modified query (with altered criteria) for before* or the filtered/extended record array for after*.
-	 */
-	accessControl: function ( model, action, options, callback ) {
-		var primaryArgument = null;
-		var capitaliseFirstLetter = function ( string ) {
-			return string.charAt( 0 ).toUpperCase() + string.slice( 1 );
-		};
-
-		if ( action.indexOf( "before" ) === 0 ) {
-			if ( !options.criteria ) throw new Error( "accessControl before* hook needs option: criteria!" );
-			primaryArgument = options.criteria;
-		} else if ( action.indexOf( "after" ) === 0 ) { // turns out that access control after querying the database is a bad idea, because counting and pagination patterns are broken
-			if ( !options.records ) throw new Error( "accessControl after* hook needs option: records!" );
-			primaryArgument = options.records;
-		} else {
-			throw new Error( "accessControl action '" + action + "' doesn't fit into before/after pattern." );
-		}
-
-		action = capitaliseFirstLetter( action );
-
-		if ( typeof model[ "control" + action ] === "function" ) {
-			primaryArgument = model[ "control" + action ]( primaryArgument, options, callback );
-		} else {
-			console.log( "Dev: Model " + model.identity + " is missing control " + action + "!" );
-			if ( callback ) {
-				callback( null, primaryArgument );
-			}
-		}
-		return primaryArgument;
-	},
-
-	/**
 	 * helper function to populate a record with an array for indexes for associated models, running various Waterline queries on the join tables if neccessary ( defined as: include -> index )
 	 * @param  {Waterine Collection}   parentModel  [description]
 	 * @param  {Array|Integer}   ids          [description]
@@ -143,8 +107,6 @@ module.exports = {
 		var _options = req.options;
 		var aliasFilter = req.param( 'populate' );
 		var shouldPopulate = _options.populate;
-
-		console.log( "Populate: ", aliasFilter, shouldPopulate );
 
 		// Convert the string representation of the filter list to an Array. We
 		// need this to provide flexibility in the request param. This way both

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -79,10 +79,19 @@ var Ember = {
 							return filtered;
 						}, [] );
 					}
-					if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
-						if ( rec[ emberModelIdentity ] === record.id ) filtered.push( rec.id );
-						return filtered;
-					}, [] );
+					if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) {
+						if ( assoc.through ) { // handle hasMany-Through associations
+							if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
+								if ( rec[ emberModelIdentity ] === record.id ) filtered.push( rec[ assoc.collection ] );
+								return filtered;
+							}, [] );
+						} else {
+							record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
+								if ( rec[ emberModelIdentity ] === record.id ) filtered.push( rec.id );
+								return filtered;
+							}, [] );
+						}
+					}
 					// @todo if assoc.include startsWith index: ... fill contents from selected column of join table
 					if ( assoc.include === "link" ) {
 						links[ assoc.alias ] = sails.config.blueprints.prefix + "/" + modelPlural.toLowerCase() + "/" + record.id + "/" + assoc.alias;

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -148,7 +148,6 @@ var Ember = {
 				if ( array.length > 0 ) {
 					if ( !_.isNumber( array[ 0 ] ) && !_.isString( array[ 0 ] ) ) { // this is probably an array of records
 						var model = sails.models[ pluralize( key, 1 ) ];
-						console.log( "Sideloaded records model: ", model.identity );
 						Ember.linkAssociations( model, array );
 					}
 				}


### PR DESCRIPTION
This PR enables the `Ember.buildResponse` function to handle Many-to-Many-Through associations as currently supported in Sails.
