### PR TITLE
Use original/global ModelNames in Ember JSON response.

### DIFF
--- a/templates/advanced/api/blueprints/_util/actionUtil.js
+++ b/templates/advanced/api/blueprints/_util/actionUtil.js
@@ -311,7 +311,7 @@ module.exports = {
 		}
 
 		// Get values using the model identity as resource identifier
-		var values = req.param( _.camelCase( model.globalId ) ) || {};
+		var values = req.param( model.globalId ) || {};
 
 		// Omit built-in runtime config (like query modifiers)
 		values = _.omit( values, blacklist || [] );

--- a/templates/advanced/api/blueprints/_util/actionUtil.js
+++ b/templates/advanced/api/blueprints/_util/actionUtil.js
@@ -311,7 +311,7 @@ module.exports = {
 		}
 
 		// Get values using the model identity as resource identifier
-		var values = req.param( model.globalId ) || {};
+		var values = req.param( _.kebabCase( model.globalId ) ) || {};
 
 		// Omit built-in runtime config (like query modifiers)
 		values = _.omit( values, blacklist || [] );

--- a/templates/advanced/api/blueprints/populate.js
+++ b/templates/advanced/api/blueprints/populate.js
@@ -91,7 +91,7 @@ module.exports = function expand( req, res ) {
 			var RelatedModel = req._sails.models[ relationIdentity ];
 			if ( !RelatedModel ) throw new Error( util.format( 'Invalid route option, "model".\nI don\'t know about any models named: `%s`', relationIdentity ) );
 
-			documentIdentifier = pluralize( RelatedModel.globalId );
+			documentIdentifier = pluralize( _.kebabCase( RelatedModel.globalId ) );
 			var related = Ember.linkAssociations( RelatedModel, matchingRecord[ relation ] );
 
 			var json = {};

--- a/templates/advanced/api/blueprints/populate.js
+++ b/templates/advanced/api/blueprints/populate.js
@@ -91,7 +91,7 @@ module.exports = function expand( req, res ) {
 			var RelatedModel = req._sails.models[ relationIdentity ];
 			if ( !RelatedModel ) throw new Error( util.format( 'Invalid route option, "model".\nI don\'t know about any models named: `%s`', relationIdentity ) );
 
-			var documentIdentifier = pluralize( _.camelCase( RelatedModel.globalId ));
+			documentIdentifier = pluralize( RelatedModel.globalId );
 			var related = Ember.linkAssociations( RelatedModel, matchingRecord[ relation ] );
 
 			var json = {};

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -39,7 +39,7 @@ var Ember = {
 		sideload = sideload || false;
 		var plural = Array.isArray( records ) ? true : false;
 
-		var emberModelIdentity = _.camelCase( model.globalId );
+		var emberModelIdentity = model.globalId;
 		var modelPlural = pluralize( emberModelIdentity );
 		var documentIdentifier = modelPlural; //plural ? modelPlural : emberModelIdentity;
 		var json = {};
@@ -51,10 +51,11 @@ var Ember = {
 			_.each( associations, function ( assoc ) {
 				// only sideload, when the full records are to be included, more info on setup here https://github.com/Incom/incom-api/wiki/Models:-Defining-associations
 				if ( assoc.include === "record" ) {
+          var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
 					var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 					// initialize jsoning object
 					if ( !json.hasOwnProperty( assoc.alias ) ) {
-						json[ assocName ] = [];
+						json[ assocModelIdentifier ] = [];
 					}
 				}
 			} );
@@ -66,13 +67,14 @@ var Ember = {
 			var links = {};
 
 			_.each( associations, function ( assoc ) {
+        var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
 				var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 				var assocModel;
 				if ( assoc.type === "collection" ) {
 					assocModel = sails.models[ assoc.collection ];
 					if ( sideload && assoc.include === "record" && record[ assoc.alias ] && record[ assoc.alias ].length > 0 ) {
 						// sideload association records with links for 3rd level associations
-						json[ assocName ] = json[ assocName ].concat( Ember.linkAssociations( assocModel, record[ assoc.alias ] ) );
+						json[ assocModelIdentifier ] = json[ assocModelIdentifier ].concat( Ember.linkAssociations( assocModel, record[ assoc.alias ] ) );
 						// reduce association on primary record to an array of IDs
 						record[ assoc.alias ] = _.reduce( record[ assoc.alias ], function ( filtered, rec ) {
 							filtered.push( rec.id );
@@ -103,7 +105,7 @@ var Ember = {
 					if ( sideload && assoc.include === "record" ) {
 						assocModel = sails.models[ assoc.model ];
 						var linkedRecords = Ember.linkAssociations( assocModel, record[ assoc.alias ] );
-						json[ assocName ] = json[ assocName ].concat( record[ assoc.alias ] );
+						json[ assocModelIdentifier ] = json[ assocModelIdentifier ].concat( record[ assoc.alias ] );
 						record[ assoc.alias ] = linkedRecords[ 0 ].id; // reduce embedded record to id
 					}
 					/* if ( assoc.include === "link" ) { // while it's possible, we should not really do this
@@ -144,10 +146,11 @@ var Ember = {
 
 			// add *links* for relationships to sideloaded records
 			_.each( json, function ( array, key ) {
+        console.log(key, pluralize(key, 1));
 				if ( key === documentIdentifier ) return;
 				if ( array.length > 0 ) {
 					if ( !_.isNumber( array[ 0 ] ) && !_.isString( array[ 0 ] ) ) { // this is probably an array of records
-						var model = sails.models[ pluralize( key, 1 ) ];
+						var model = sails.models[ pluralize( key, 1 ).toLowerCase() ];
 						Ember.linkAssociations( model, array );
 					}
 				}

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -41,7 +41,7 @@ var Ember = {
 
 		var emberModelIdentity = model.globalId;
 		var modelPlural = pluralize( emberModelIdentity );
-		var documentIdentifier = modelPlural; //plural ? modelPlural : emberModelIdentity;
+		var documentIdentifier = _.kebabCase( modelPlural ); //plural ? modelPlural : emberModelIdentity;
 		var json = {};
 
 		json[ documentIdentifier ] = [];
@@ -51,7 +51,7 @@ var Ember = {
 			_.each( associations, function ( assoc ) {
 				// only sideload, when the full records are to be included, more info on setup here https://github.com/Incom/incom-api/wiki/Models:-Defining-associations
 				if ( assoc.include === "record" ) {
-					var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
+					var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
 					var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 					// initialize jsoning object
 					if ( !json.hasOwnProperty( assoc.alias ) ) {
@@ -67,7 +67,7 @@ var Ember = {
 			var links = {};
 
 			_.each( associations, function ( assoc ) {
-				var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
+				var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
 				var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 				var assocModel;
 				if ( assoc.type === "collection" ) {
@@ -149,7 +149,7 @@ var Ember = {
 				if ( key === documentIdentifier ) return;
 				if ( array.length > 0 ) {
 					if ( !_.isNumber( array[ 0 ] ) && !_.isString( array[ 0 ] ) ) { // this is probably an array of records
-						var model = sails.models[ pluralize( key, 1 ).toLowerCase() ];
+						var model = sails.models[ pluralize( _.camelCase(key).toLowerCase(), 1 ) ];
 						Ember.linkAssociations( model, array );
 					}
 				}

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -52,7 +52,6 @@ var Ember = {
 				// only sideload, when the full records are to be included, more info on setup here https://github.com/Incom/incom-api/wiki/Models:-Defining-associations
 				if ( assoc.include === "record" ) {
 					var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
-					var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 					// initialize jsoning object
 					if ( !json.hasOwnProperty( assoc.alias ) ) {
 						json[ assocModelIdentifier ] = [];
@@ -68,7 +67,6 @@ var Ember = {
 
 			_.each( associations, function ( assoc ) {
 				var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
-				var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 				var assocModel;
 				if ( assoc.type === "collection" ) {
 					assocModel = sails.models[ assoc.collection ];
@@ -84,12 +82,12 @@ var Ember = {
 					if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) {
 						if ( assoc.through ) { // handle hasMany-Through associations
 							if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
-								if ( rec[ emberModelIdentity ] === record.id ) filtered.push( rec[ assoc.collection ] );
+								if ( rec [ assoc.via ] === record.id ) filtered.push( rec[ assoc.collection ] );
 								return filtered;
 							}, [] );
 						} else {
 							record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
-								if ( rec[ emberModelIdentity ] === record.id ) filtered.push( rec.id );
+								if ( rec [ assoc.via ] === record.id ) filtered.push( rec.id );
 								return filtered;
 							}, [] );
 						}

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -51,7 +51,7 @@ var Ember = {
 			_.each( associations, function ( assoc ) {
 				// only sideload, when the full records are to be included, more info on setup here https://github.com/Incom/incom-api/wiki/Models:-Defining-associations
 				if ( assoc.include === "record" ) {
-          var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
+					var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
 					var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 					// initialize jsoning object
 					if ( !json.hasOwnProperty( assoc.alias ) ) {
@@ -67,7 +67,7 @@ var Ember = {
 			var links = {};
 
 			_.each( associations, function ( assoc ) {
-        var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
+				var assocModelIdentifier = pluralize(sails.models[assoc.collection || assoc.model].globalId);
 				var assocName = assoc.type === "collection" ? pluralize( assoc.collection ) : pluralize( assoc.model );
 				var assocModel;
 				if ( assoc.type === "collection" ) {
@@ -146,7 +146,6 @@ var Ember = {
 
 			// add *links* for relationships to sideloaded records
 			_.each( json, function ( array, key ) {
-        console.log(key, pluralize(key, 1));
 				if ( key === documentIdentifier ) return;
 				if ( array.length > 0 ) {
 					if ( !_.isNumber( array[ 0 ] ) && !_.isString( array[ 0 ] ) ) { // this is probably an array of records


### PR DESCRIPTION
Original PR from @aars

I'm not sure if merging this is a good idea, since it would probably break any project that was used to the previous inconsistent camelCased and/or undercased model names. But in my opinion the previous implementation is broken. Not just because of the of inconsistent reformatting of the model name, which is confusing to say the least.

These changes work perfectly with my current Ember(-data) setup. My models now have the same name in the frontend and backend. Ember(-data) does not require camelCased model names. So by reformatting the model names you are forcing the frontend to use a certain naming convention which, as far as I can tell, is not any official or preferred convention.

But, it seems unlikely that the camelCasing of model names was an accident. There probably was a reason for doing that. What was the reason? Maybe older versions of Ember? Non Ember-data usage? As far as I can tell all Ember implementations could handle these ModelNames as well.

More discussion here https://github.com/mphasize/sails-generate-ember-blueprints/pull/37
