### PR TITLE
HOTFIX: Added support restPrefix

### DIFF
--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -11,12 +11,12 @@ var Ember = {
 	linkAssociations: function ( model, records ) {
 		if ( !Array.isArray( records ) ) records = [ records ];
 		var modelPlural = pluralize( model.identity );
-
+		var prefix = sails.config.blueprints.restPrefix || sails.config.blueprints.prefix;
 		return _.map( records, function ( record ) {
 			var links = {};
 			_.each( model.associations, function ( assoc ) {
 				if ( assoc.type === "collection" ) {
-					links[ assoc.alias ] = sails.config.blueprints.prefix + "/" + modelPlural + "/" + record.id + "/" + assoc.alias;
+					links[ assoc.alias ] = prefix + "/" + modelPlural + "/" + record.id + "/" + assoc.alias;
 				}
 			} );
 			if ( _.size( links ) > 0 ) {
@@ -43,6 +43,7 @@ var Ember = {
 		var modelPlural = pluralize( emberModelIdentity );
 		var documentIdentifier = _.kebabCase( modelPlural ); //plural ? modelPlural : emberModelIdentity;
 		var json = {};
+		var prefix = sails.config.blueprints.restPrefix || sails.config.blueprints.prefix;
 
 		json[ documentIdentifier ] = [];
 
@@ -99,7 +100,7 @@ var Ember = {
 					}
 					// @todo if assoc.include startsWith index: ... fill contents from selected column of join table
 					if ( assoc.include === "link" ) {
-						links[ assoc.alias ] = sails.config.blueprints.prefix + "/" + modelPlural.toLowerCase() + "/" + record.id + "/" + assoc.alias;
+						links[ assoc.alias ] = prefix + "/" + modelPlural.toLowerCase() + "/" + record.id + "/" + assoc.alias;
 						delete record[ assoc.alias ];
 					}
 					//record[ assoc.alias ] = _.pluck( record[ assoc.alias ], 'id' );

--- a/templates/basic/api/services/Ember.js
+++ b/templates/basic/api/services/Ember.js
@@ -14,11 +14,12 @@ module.exports = {
     if ( !Array.isArray( records ) ) records = [ records ];
     var modelPlural = pluralize( model.identity );
 
+    var prefix = sails.config.blueprints.restPrefix || sails.config.blueprints.prefix;
     return map( records, function ( record ) {
       var links = {};
       forEach( model.associations, function ( assoc ) {
         if ( assoc.type == "collection" ) {
-          links[ assoc.alias ] = sails.config.blueprints.prefix + "/" + modelPlural + "/" + record.id + "/" + assoc.alias;
+          links[ assoc.alias ] = prefix + "/" + modelPlural + "/" + record.id + "/" + assoc.alias;
         }
       } );
       if ( size( links ) > 0 ) {


### PR DESCRIPTION
in Sails 0.11 added new property `restPrefix` to 'config/blueprints.js'

``` javascript
  /***************************************************************************
   *                                                                          *
   * An optional mount path for all REST blueprint routes on a controller.    *
   * And it do not include `actions` and `shortcuts` routes.                  *
   * This allows you to take advantage of REST blueprint routing,             *
   * even if you need to namespace your RESTful API methods                   *
   *                                                                          *
   ***************************************************************************/

  restPrefix: '/api/v5',
```
