### PR TITLE
Custom Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ The `index` setting will generate an array of ID references for Ember Data, so b
 
 The `record` setting will sideload the complete record.
 
+**Custom Responses**
+The blueprints normally reply with the `ok` response from `api/responses/ok.js`. The advanced blueprints allow you to set a custom response in `config/blueprints` for *find, findOne and populate* blueprints.
+
+Example:
+Assuming a file named `api/responses/myRes.js` exists.
+
+	// config/blueprints.js 
+	module.exports.blueprints = {
+
+		findResponse: 'myRes',
+		findOneResponse: 'myRes',
+		populateResponse: 'myRes',
+	
+		// ....
+	}
+
+
 
 ### Troubleshooting
 

--- a/templates/advanced/api/blueprints/find.js
+++ b/templates/advanced/api/blueprints/find.js
@@ -81,8 +81,9 @@ module.exports = function findRecords( req, res ) {
 				emberizedJSON.meta = {
 					total: results.count
 				};
-				res.ok( emberizedJSON );
 
+				var customResponse = sails.config.blueprints.findResponse || 'ok';
+				res[customResponse]( emberizedJSON );
 			} );
 		} );
 

--- a/templates/advanced/api/blueprints/findone.js
+++ b/templates/advanced/api/blueprints/findone.js
@@ -41,7 +41,8 @@ module.exports = function findOneRecord( req, res ) {
 				actionUtil.subscribeDeep( req, matchingRecord );
 			}
 
-			res.ok( Ember.buildResponse( Model, matchingRecord, associations, true, associated ) );
+			var customResponse = sails.config.blueprints.findResponse || 'ok';
+			res[customResponse]( Ember.buildResponse( Model, matchingRecord, associations, true, associated ) );
 
 		} );
 

--- a/templates/advanced/api/blueprints/populate.js
+++ b/templates/advanced/api/blueprints/populate.js
@@ -96,6 +96,8 @@ module.exports = function expand( req, res ) {
 
 			var json = {};
 			json[ documentIdentifier ] = related;
-			res.ok( json );
+
+			var customResponse = sails.config.blueprints.populateResponse || 'ok';
+			res[customResponse]( json );
 		} );
 };


### PR DESCRIPTION
The blueprints normally reply with the `ok` response from `api/responses/ok.js`.

This PR enables setting a custom response in `config/blueprints` for _find, findOne and populate_ blueprints.

Example:
Assuming a file named `api/responses/myRes.js` exists.

``` javascript
// config/blueprints.js 
module.exports.blueprints = {

    findResponse: 'myRes',
    findOneResponse: 'myRes',
    populateResponse: 'myRes',

    // ....
}
```
