### PR TITLE
Model.toJSON promise support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.1.1",
     "lodash": "~3.2.0",
-    "pluralize": "^1.1.0",
-    "merge-defaults": "^0.2.1"
+    "merge-defaults": "^0.2.1",
+    "pluralize": "^1.1.0"
   },
   "devDependencies": {
     "glob": "^5.0.5",

--- a/templates/advanced/api/blueprints/find.js
+++ b/templates/advanced/api/blueprints/find.js
@@ -76,14 +76,13 @@ module.exports = function findRecords( req, res ) {
 					} );
 				}
 
-				var emberizedJSON = Ember.buildResponse( Model, results.records, associations, true, associated );
-
-				emberizedJSON.meta = {
-					total: results.count
-				};
-				res.ok( emberizedJSON );
-
-			} );
+				Ember.buildResponse(Model, results.records, associations, true, associated).then(function (emberizedJSON) {
+          emberizedJSON.meta = {
+            total: results.count
+          };
+          res.ok( emberizedJSON );
+        });
+			});
 		} );
 
 	/*async.reduce( associations, {}, function ( associatedRecords, association, next ) {

--- a/templates/advanced/api/blueprints/findone.js
+++ b/templates/advanced/api/blueprints/findone.js
@@ -41,7 +41,9 @@ module.exports = function findOneRecord( req, res ) {
 				actionUtil.subscribeDeep( req, matchingRecord );
 			}
 
-			res.ok( Ember.buildResponse( Model, matchingRecord, associations, true, associated ) );
+			Ember.buildResponse( Model, matchingRecord, associations, true, associated ).then(function (emberizedJSON) {
+        res.ok(emberizedJSON);
+      });
 
 		} );
 

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -82,7 +82,7 @@ var Ember = {
 					assocPks[assocModelIdentifier] = assocPk;
 					var via = _.kebabCase(emberModelIdentity);
 					// check if inverse is using a different name
-					if(via !== pluralize(assoc.via,1)) {
+					if(assoc.via && via !== pluralize(assoc.via,1)) {
 						via = pluralize(assoc.via, 1);
 					}
 					if ( sideload && assoc.include === "record" && record[ assoc.alias ] && record[ assoc.alias ].length > 0 ) {

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -72,7 +72,7 @@ var Ember = {
           // Support promise from toJSON()
           Promise.all([record.toJSON()]).then(function (recordJSON) {
             // get rid of the record's prototype ( otherwise the .toJSON called in res.send would re-insert embedded records)
-            record = _.create( {}, recordJSON );
+            record = _.create( {}, recordJSON[0] );
             var links = {};
 
             _.each( associations, function ( assoc ) {

--- a/templates/advanced/api/services/Ember.js
+++ b/templates/advanced/api/services/Ember.js
@@ -6,6 +6,7 @@
 
 var _ = require( 'lodash' ),
 	pluralize = require( 'pluralize' );
+  Promise = require('bluebird');
 
 var Ember = {
 	linkAssociations: function ( model, records ) {
@@ -51,128 +52,143 @@ var Ember = {
 		var prefix = sails.config.blueprints.restPrefix || sails.config.blueprints.prefix;
 
 		json[ documentIdentifier ] = [];
+    return new Promise(function (resolve, reject) {
+      if ( sideload ) {
+        // prepare for sideloading
+        _.each( associations, function ( assoc ) {
+          // only sideload, when the full records are to be included, more info on setup here https://github.com/Incom/incom-api/wiki/Models:-Defining-associations
+          if ( assoc.include === "record" ) {
+            var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
+            // initialize jsoning object
+            if ( !json.hasOwnProperty( assoc.alias ) ) {
+              json[ assocModelIdentifier ] = [];
+            }
+          }
+        } );
+      }
 
-		if ( sideload ) {
-			// prepare for sideloading
-			_.each( associations, function ( assoc ) {
-				// only sideload, when the full records are to be included, more info on setup here https://github.com/Incom/incom-api/wiki/Models:-Defining-associations
-				if ( assoc.include === "record" ) {
-					var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
-					// initialize jsoning object
-					if ( !json.hasOwnProperty( assoc.alias ) ) {
-						json[ assocModelIdentifier ] = [];
-					}
-				}
-			} );
-		}
+      var prepareOneRecord = function ( record ) {
+        return new Promise(function (resolve, reject) {
+          // Support promise from toJSON()
+          Promise.all([record.toJSON()]).then(function (recordJSON) {
+            // get rid of the record's prototype ( otherwise the .toJSON called in res.send would re-insert embedded records)
+            record = _.create( {}, recordJSON );
+            var links = {};
 
-		var prepareOneRecord = function ( record ) {
-			// get rid of the record's prototype ( otherwise the .toJSON called in res.send would re-insert embedded records)
-			record = _.create( {}, record.toJSON() );
-			var links = {};
+            _.each( associations, function ( assoc ) {
+              var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
+              var assocModel;
+              var assocPk;
 
-			_.each( associations, function ( assoc ) {
-				var assocModelIdentifier = pluralize( _.kebabCase( sails.models[assoc.collection || assoc.model].globalId ) );
-				var assocModel;
-				var assocPk;
-
-				if ( assoc.type === "collection" ) {
-					assocModel = sails.models[ assoc.collection ];
-					assocPk = assocModel.primaryKey
-					assocPks[assocModelIdentifier] = assocPk;
-					var via = _.kebabCase(emberModelIdentity);
-					// check if inverse is using a different name
-					if(assoc.via && via !== pluralize(assoc.via,1)) {
-						via = pluralize(assoc.via, 1);
-					}
-					if ( sideload && assoc.include === "record" && record[ assoc.alias ] && record[ assoc.alias ].length > 0 ) {
-						// sideload association records with links for 3rd level associations
-						json[ assocModelIdentifier ] = json[ assocModelIdentifier ].concat( Ember.linkAssociations( assocModel, record[ assoc.alias ] ) );
-						// reduce association on primary record to an array of IDs
-						record[ assoc.alias ] = _.reduce( record[ assoc.alias ], function ( filtered, rec ) {
-							filtered.push( rec[assocPk] );
-							return filtered;
-						}, [] );
-					}
-					if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) {
-						if ( assoc.through ) { // handle hasMany-Through associations
-							if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
-								if ( rec [ via ] === record[pk] ) filtered.push( rec[ assoc.collection ] );
-								return filtered;
-							}, [] );
-						} else {
-							record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
-								if ( rec [ via ] === record[pk] ) filtered.push( rec[assocPk] );
-								return filtered;
-							}, [] );
-						}
-					}
-					// @todo if assoc.include startsWith index: ... fill contents from selected column of join table
-					if ( assoc.include === "link" ) {
-						links[ assoc.alias ] = prefix + "/" + modelPlural.toLowerCase() + "/" + record[pk] + "/" + assoc.alias;
-						delete record[ assoc.alias ];
-					}
-					//record[ assoc.alias ] = _.pluck( record[ assoc.alias ], 'id' );
-				}
-				if ( assoc.type === "model" && record[ assoc.alias ] ) {
-					if ( sideload && assoc.include === "record" ) {
-						assocModel = sails.models[ assoc.model ];
-						assocPk = assocModel.primaryKey;
-						var linkedRecords = Ember.linkAssociations( assocModel, record[ assoc.alias ] );
-						json[ assocModelIdentifier ] = json[ assocModelIdentifier ].concat( record[ assoc.alias ] );
-						record[ assoc.alias ] = linkedRecords[ 0 ][assocPk]; // reduce embedded record to id
-					}
-					/* if ( assoc.include === "link" ) { // while it's possible, we should not really do this
-						links[ assoc.alias ] = sails.config.blueprints.prefix + "/" + modelPlural.toLowerCase() + "/" + record.id + "/" + assoc.alias;
-						delete record[ assoc.alias ];
-					} */
-					// if "index" we're already done...
-				}
-			} );
-			if ( _.size( links ) > 0 ) {
-				record.links = links;
-			}
-			return record;
+              if ( assoc.type === "collection" ) {
+                assocModel = sails.models[ assoc.collection ];
+                assocPk = assocModel.primaryKey
+                assocPks[assocModelIdentifier] = assocPk;
+                var via = _.kebabCase(emberModelIdentity);
+                // check if inverse is using a different name
+                if(assoc.via && via !== pluralize(assoc.via,1)) {
+                  via = pluralize(assoc.via, 1);
+                }
+                if ( sideload && assoc.include === "record" && record[ assoc.alias ] && record[ assoc.alias ].length > 0 ) {
+                  // sideload association records with links for 3rd level associations
+                  json[ assocModelIdentifier ] = json[ assocModelIdentifier ].concat( Ember.linkAssociations( assocModel, record[ assoc.alias ] ) );
+                  // reduce association on primary record to an array of IDs
+                  record[ assoc.alias ] = _.reduce( record[ assoc.alias ], function ( filtered, rec ) {
+                    filtered.push( rec[assocPk] );
+                    return filtered;
+                  }, [] );
+                }
+                if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) {
+                  if ( assoc.through ) { // handle hasMany-Through associations
+                    if ( assoc.include === "index" && associatedRecords[ assoc.alias ] ) record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
+                      if ( rec [ via ] === record[pk] ) filtered.push( rec[ assoc.collection ] );
+                      return filtered;
+                    }, [] );
+                  } else {
+                    record[ assoc.alias ] = _.reduce( associatedRecords[ assoc.alias ], function ( filtered, rec ) {
+                      if ( rec [ via ] === record[pk] ) filtered.push( rec[assocPk] );
+                      return filtered;
+                    }, [] );
+                  }
+                }
+                // @todo if assoc.include startsWith index: ... fill contents from selected column of join table
+                if ( assoc.include === "link" ) {
+                  links[ assoc.alias ] = prefix + "/" + modelPlural.toLowerCase() + "/" + record[pk] + "/" + assoc.alias;
+                  delete record[ assoc.alias ];
+                }
+                //record[ assoc.alias ] = _.pluck( record[ assoc.alias ], 'id' );
+              }
+              if ( assoc.type === "model" && record[ assoc.alias ] ) {
+                if ( sideload && assoc.include === "record" ) {
+                  assocModel = sails.models[ assoc.model ];
+                  assocPk = assocModel.primaryKey;
+                  var linkedRecords = Ember.linkAssociations( assocModel, record[ assoc.alias ] );
+                  json[ assocModelIdentifier ] = json[ assocModelIdentifier ].concat( record[ assoc.alias ] );
+                  record[ assoc.alias ] = linkedRecords[ 0 ][assocPk]; // reduce embedded record to id
+                }
+                /* if ( assoc.include === "link" ) { // while it's possible, we should not really do this
+                  links[ assoc.alias ] = sails.config.blueprints.prefix + "/" + modelPlural.toLowerCase() + "/" + record.id + "/" + assoc.alias;
+                  delete record[ assoc.alias ];
+                } */
+                // if "index" we're already done...
+              }
+            } );
+            if ( _.size( links ) > 0 ) {
+              record.links = links;
+            }
+            resolve(record);
+          });
+        });
 		};
 
 		// many or just one?
+    var promises = [];
 		if ( plural ) {
 			_.each( records, function ( record ) {
-				json[ documentIdentifier ] = json[ documentIdentifier ].concat( prepareOneRecord( record ) );
+        var p = prepareOneRecord(record).then(function (record) {
+				  json[ documentIdentifier ] = json[ documentIdentifier ].concat( record );
+        });
+        promises.push(p);
 			} );
 		} else {
-			json[ documentIdentifier ] = [ prepareOneRecord( records ) ];
+      var p = prepareOneRecord(records).then(function (records) {
+			  json[ documentIdentifier ] = [ records ];
+      });
+      promises.push(p);
 		}
 
-		if ( sideload ) {
-			var pk;
-			// filter duplicates in sideloaded records
-			// @todo: prune empty association arrays
-			_.each( json, function ( array, key ) {
-				if ( key === documentIdentifier ) return;
-				if ( json[ key ].length === 0 ) {
-					delete json[ key ];
-					return;
-				}
-				pk = assocPks[key];
-				json[ key ] = _.uniq( array, function ( record ) {
-					return record[pk];
-				} );
-			} );
+    Promise.all(promises).then(function () {
+      if ( sideload ) {
+        var pk;
+        // filter duplicates in sideloaded records
+        // @todo: prune empty association arrays
+        _.each( json, function ( array, key ) {
+          if ( key === documentIdentifier ) return;
+          if ( json[ key ].length === 0 ) {
+            delete json[ key ];
+            return;
+          }
+          pk = assocPks[key];
+          json[ key ] = _.uniq( array, function ( record ) {
+            return record[pk];
+          } );
+        } );
 
-			// add *links* for relationships to sideloaded records
-			_.each( json, function ( array, key ) {
-				if ( key === documentIdentifier ) return;
-				if ( array.length > 0 ) {
-					if ( !_.isNumber( array[ 0 ] ) && !_.isString( array[ 0 ] ) ) { // this is probably an array of records
-						var model = sails.models[ pluralize( _.camelCase(key).toLowerCase(), 1 ) ];
-						Ember.linkAssociations( model, array );
-					}
-				}
-			} );
-		}
+        // add *links* for relationships to sideloaded records
+        _.each( json, function ( array, key ) {
+          if ( key === documentIdentifier ) return;
+          if ( array.length > 0 ) {
+            if ( !_.isNumber( array[ 0 ] ) && !_.isString( array[ 0 ] ) ) { // this is probably an array of records
+              var model = sails.models[ pluralize( _.camelCase(key).toLowerCase(), 1 ) ];
+              Ember.linkAssociations( model, array );
+            }
+          }
+        });
+      }
 
-		return json;
+        resolve(json);
+      });
+    });
 	}
 };
 


### PR DESCRIPTION
I've got this as well. Not very pretty, and only applied on advanced templates. I'm leaving sails soon, so I wont be putting in much more effort. But I needed this to work around some Waterline restrictions (reverse one-way relation lookup).

I think it's useful tough. If you want I'll apply it to the basic templates as well. But I'm still not sure if supporting promises here is a good thing. Of course supporting promises is a good thing, but it should be supported by sails. 
